### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 
 description = "ReadingBat Site"
 group = "com.github.readingbat"
-version = "3.0.0"
+version = "3.1.0"
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   readingbat0:
-    image: "pambrose/readingbat:3.0.0"
+    image: "pambrose/readingbat:3.1.0"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -9,7 +9,7 @@ services:
       - "8083:8083"
       - "8084:8084"
   readingbat1:
-    image: "pambrose/readingbat:3.0.0"
+    image: "pambrose/readingbat:3.1.0"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -17,7 +17,7 @@ services:
       - "8093:8083"
       - "8094:8084"
   readingbat2:
-    image: "pambrose/readingbat:3.0.0"
+    image: "pambrose/readingbat:3.1.0"
     restart: "always"
     env_file: docker_env_vars
     ports:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ buildconfig = "6.0.9"
 
 # Dependencies
 logging = "8.0.01"
-readingbat = "3.0.0"
+readingbat = "3.0.1"
 ktor = "3.4.1"
 
 [libraries]

--- a/machines/content/run.sh
+++ b/machines/content/run.sh
@@ -1,1 +1,1 @@
-docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.0.0
+docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.1.0


### PR DESCRIPTION
## Summary
- Bump app version from 3.0.0 to 3.1.0 in build.gradle.kts, docker-compose.yml, and machines/content/run.sh
- Update readingbat dependency from 3.0.0 to 3.0.1 in libs.versions.toml

## Test plan
- [ ] Verify the app builds successfully with `./gradlew build`
- [ ] Verify Docker image builds with the new version tag
- [ ] Confirm readingbat 3.0.1 dependency resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)