### PR TITLE
Clean up code review findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ EXPOSE 8092
 EXPOSE 8093
 
 # Launch java to execute the jar with defaults intended for containers.
-ENTRYPOINT ["java", "-server", "-XX:+UseContainerSupport", "-Xmx2048m", "-Dkotlin.script.classpath=/app/server.jar", "-Dlogback.configurationFile=/app/src/main/resources/logback.xml", "-javaagent:/app/jmx/jmx_prometheus_javaagent-1.5.0.jar=8081:/app/jmx/config.yaml", "-jar", "/app/server.jar"]
+ENTRYPOINT ["java", "-server", "-Xmx2048m", "-Dkotlin.script.classpath=/app/server.jar", "-Dlogback.configurationFile=/app/src/main/resources/logback.xml", "-javaagent:/app/jmx/jmx_prometheus_javaagent-1.5.0.jar=8081:/app/jmx/config.yaml", "-jar", "/app/server.jar"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ReadingBat Site
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/readingbat/readingbat-site)
-[![Run on Repl.it](https://repl.it/badge/github/readingbat/readingbat-site)](https://repl.it/github/readingbat/readingbat-site)
 [![Kotlin](https://img.shields.io/badge/%20language-Kotlin-red.svg)](https://kotlinlang.org/)
 
 This repo has the content for [readingbat.com](https://readingbat.com).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,13 @@
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
   application
   alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.ktor.plugin)
   alias(libs.plugins.versions)
   alias(libs.plugins.buildconfig)
-  alias(libs.plugins.ktor.plugin)
 }
 
 repositories {
@@ -77,7 +78,7 @@ tasks.test {
   useJUnitPlatform()
 
   testLogging {
-    events("passed", "skipped", "failed", "standardOut", "standardError")
+    events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
     exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     showStandardStreams = true
   }

--- a/src/main/kotlin/ContentServer.kt
+++ b/src/main/kotlin/ContentServer.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  */
-@file:Suppress
 
 import com.github.readingbat.readingbat_site.BuildConfig.SITE_VERSION
 import com.github.readingbat.server.ReadingBatServer

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,12 +19,13 @@ readingbat {
     startupMaxDelaySecs = 90
     forwardedHeaderSupportEnabled = false
     xforwardedHeaderSupportEnabled = false
+
     oauthCallbackUrlPrefix = "https://www.readingbat.com"
 
-    githubOAuthClientId = ""
-    githubOAuthClientSecret = ""
-    googleOAuthClientId = ""
-    googleOAuthClientSecret = ""
+    githubOAuthClientId = ${GITHUB_OAUTH_CLIENT_ID}
+    githubOAuthClientSecret = ${GITHUB_OAUTH_CLIENT_SECRET}
+    googleOAuthClientId = ${GOOGLE_OAUTH_CLIENT_ID}
+    googleOAuthClientSecret = ${GOOGLE_OAUTH_CLIENT_SECRET}
   }
 
   scripts {


### PR DESCRIPTION
## Summary
- Remove redundant `-XX:+UseContainerSupport` JVM flag (default since Java 10, unnecessary on Java 21)
- Remove stale Gitpod and Repl.it badges from README
- Remove incomplete `@file:Suppress` annotation (no-op without arguments)
- Use HOCON environment variable substitution for OAuth secrets instead of empty string defaults
- Use type-safe `TestLogEvent` enum in build.gradle.kts test logging config
- Reorder plugins for consistency

## Test plan
- [ ] Verify application starts with OAuth env vars set
- [ ] Verify application starts without OAuth env vars (confirm HOCON behavior on missing vars)
- [ ] Run `make tests` to confirm test config change doesn't break tests
- [ ] Build Docker image and verify entrypoint works without the removed JVM flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)