### PR TITLE
Bump version to 3.1.3 and update readingbat-core to 3.0.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 
 description = "ReadingBat Site"
 group = "com.github.readingbat"
-version = "3.1.2"
+version = "3.1.3"
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   readingbat0:
-    image: "pambrose/readingbat:3.1.2"
+    image: "pambrose/readingbat:3.1.3"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -8,7 +8,7 @@ services:
       - "8081:8081"
       - "8083:8083"
   readingbat1:
-    image: "pambrose/readingbat:3.1.2"
+    image: "pambrose/readingbat:3.1.3"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -16,7 +16,7 @@ services:
       - "8093:8083"
       - "8094:8084"
   readingbat2:
-    image: "pambrose/readingbat:3.1.2"
+    image: "pambrose/readingbat:3.1.3"
     restart: "always"
     env_file: docker_env_vars
     ports:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ buildconfig = "6.0.9"
 
 # Dependencies
 logging = "8.0.01"
-readingbat = "3.0.3"
+readingbat = "3.0.5"
 kotest = "6.1.7"
 ktor = "3.4.1"
 

--- a/machines/content/run.sh
+++ b/machines/content/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.1.2
+docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.1.3


### PR DESCRIPTION
## Summary
- Bump site version from 3.1.2 to 3.1.3
- Update readingbat-core dependency from 3.0.3 to 3.0.5
- Update Docker image tags in docker-compose.yml and machines/content/run.sh

## Test plan
- [ ] Run `make tests` to verify compatibility with readingbat-core 3.0.5
- [ ] Build fat JAR with `make uberjar` and verify startup
- [ ] Build Docker image and confirm it runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)