### PR TITLE
Bump version to 3.2.0 and migrate to com.readingbat package namespace (#8)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,15 +10,9 @@ plugins {
   alias(libs.plugins.buildconfig)
 }
 
-repositories {
-  google()
-  mavenCentral()
-  maven { url = uri("https://jitpack.io") }
-}
-
 description = "ReadingBat Site"
-group = "com.github.readingbat"
-version = "3.1.5"
+group = "com.readingbat"
+version = "3.2.0"
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
 
@@ -26,6 +20,13 @@ buildConfig {
   buildConfigField("String", "SITE_NAME", "\"${project.name}\"")
   buildConfigField("String", "SITE_VERSION", "\"${project.version}\"")
   buildConfigField("String", "SITE_RELEASE_DATE", "\"${LocalDate.now().format(formatter)}\"")
+}
+
+repositories {
+  mavenLocal()
+  google()
+  mavenCentral()
+  maven { url = uri("https://jitpack.io") }
 }
 
 dependencies {
@@ -82,8 +83,4 @@ tasks.test {
     exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     showStandardStreams = true
   }
-}
-
-configurations.all {
-  resolutionStrategy.cacheChangingModulesFor(0, "seconds")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   readingbat0:
-    image: "pambrose/readingbat:3.1.5"
+    image: "pambrose/readingbat:3.2.0"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -8,7 +8,7 @@ services:
       - "8081:8081"
       - "8083:8083"
   readingbat1:
-    image: "pambrose/readingbat:3.1.5"
+    image: "pambrose/readingbat:3.2.0"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -16,7 +16,7 @@ services:
       - "8093:8083"
       - "8094:8084"
   readingbat2:
-    image: "pambrose/readingbat:3.1.5"
+    image: "pambrose/readingbat:3.2.0"
     restart: "always"
     env_file: docker_env_vars
     ports:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,14 +6,14 @@ buildconfig = "6.0.9"
 
 # Dependencies
 logging = "8.0.01"
-readingbat = "3.0.10"
-kotest = "6.1.9"
-ktor = "3.4.1"
+readingbat = "3.1.0"
+kotest = "6.1.11"
+ktor = "3.4.2"
 
 [libraries]
 # Dependencies
-readingbat-core = { module = "com.github.readingbat.readingbat-core:readingbat-core", version.ref = "readingbat" }
-readingbat-kotest = { module = "com.github.readingbat.readingbat-core:readingbat-kotest", version.ref = "readingbat" }
+readingbat-core = { module = "com.readingbat:readingbat-core", version.ref = "readingbat" }
+readingbat-kotest = { module = "com.readingbat:readingbat-kotest", version.ref = "readingbat" }
 kotlin-logging = { group = "io.github.oshai", name = "kotlin-logging-jvm", version.ref = "logging" }
 
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }

--- a/machines/content/run.sh
+++ b/machines/content/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.1.5
+docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.2.0

--- a/src/main/kotlin/Content.kt
+++ b/src/main/kotlin/Content.kt
@@ -1,8 +1,24 @@
-import com.github.pambrose.common.util.OwnerType.Organization
-import com.github.pambrose.common.util.OwnerType.User
-import com.github.readingbat.dsl.GitHubContent
-import com.github.readingbat.dsl.eval
-import com.github.readingbat.dsl.readingBatContent
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+import com.pambrose.common.util.OwnerType.Organization
+import com.pambrose.common.util.OwnerType.User
+import com.readingbat.dsl.GitHubContent
+import com.readingbat.dsl.eval
+import com.readingbat.dsl.readingBatContent
 
 val content =
   readingBatContent {

--- a/src/main/kotlin/ContentServer.kt
+++ b/src/main/kotlin/ContentServer.kt
@@ -1,22 +1,21 @@
 /*
- * Copyright © 2021 Paul Ambrose (pambrose@mac.com)
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 
-import com.github.readingbat.readingbat_site.BuildConfig.SITE_VERSION
-import com.github.readingbat.server.ReadingBatServer
+import com.readingbat.readingbat_site.BuildConfig.SITE_VERSION
+import com.readingbat.server.ReadingBatServer
 
 fun main(args: Array<String>) {
   ReadingBatServer.start(SITE_VERSION, args)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -68,7 +68,7 @@ ktor {
   }
 
   application {
-    modules = [com.github.readingbat.server.ReadingBatServerKt.module]
+    modules = [com.readingbat.server.ReadingBatServerKt.module]
   }
 }
 

--- a/src/test/kotlin/ContentTests.kt
+++ b/src/test/kotlin/ContentTests.kt
@@ -1,13 +1,29 @@
-import com.github.readingbat.kotest.TestSupport
-import com.github.readingbat.kotest.TestSupport.answerAllWith
-import com.github.readingbat.kotest.TestSupport.answerAllWithCorrectAnswer
-import com.github.readingbat.kotest.TestSupport.forEachAnswer
-import com.github.readingbat.kotest.TestSupport.forEachChallenge
-import com.github.readingbat.kotest.TestSupport.forEachGroup
-import com.github.readingbat.kotest.TestSupport.forEachLanguage
-import com.github.readingbat.kotest.TestSupport.shouldHaveAnswer
-import com.github.readingbat.kotest.TestSupport.testModule
-import com.github.readingbat.posts.AnswerStatus
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+import com.readingbat.kotest.TestSupport
+import com.readingbat.kotest.TestSupport.answerAllWith
+import com.readingbat.kotest.TestSupport.answerAllWithCorrectAnswer
+import com.readingbat.kotest.TestSupport.forEachAnswer
+import com.readingbat.kotest.TestSupport.forEachChallenge
+import com.readingbat.kotest.TestSupport.forEachGroup
+import com.readingbat.kotest.TestSupport.forEachLanguage
+import com.readingbat.kotest.TestSupport.shouldHaveAnswer
+import com.readingbat.kotest.TestSupport.testModule
+import com.readingbat.posts.AnswerStatus
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeBlank


### PR DESCRIPTION
## Summary
- Migrate package namespace from `com.github.readingbat`/`com.github.pambrose` to `com.readingbat`/`com.pambrose`
- Bump version from 3.1.5 to 3.2.0
- Update dependencies: readingbat-core 3.0.10 → 3.1.0, kotest 6.1.9 → 6.1.11, ktor 3.4.1 → 3.4.2
- Add license headers to Content.kt and ContentTests.kt, update copyright year to 2026
- Add `mavenLocal()` repository, remove `resolutionStrategy.cacheChangingModulesFor` config

## Test plan
- [ ] Verify Gradle build compiles successfully with new package paths
- [ ] Run all Kotest tests to confirm no regressions
- [ ] Verify Docker image builds with updated version tag 3.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)