### PR TITLE
Update readingbat-core to 3.1.1 and clean up repositories (#9)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,10 +23,9 @@ buildConfig {
 }
 
 repositories {
-  mavenLocal()
+  // mavenLocal()
   google()
   mavenCentral()
-  maven { url = uri("https://jitpack.io") }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ buildconfig = "6.0.9"
 
 # Dependencies
 logging = "8.0.01"
-readingbat = "3.1.0"
+readingbat = "3.1.1"
 kotest = "6.1.11"
 ktor = "3.4.2"
 


### PR DESCRIPTION
## Summary
- Bump readingbat-core dependency from 3.1.0 to 3.1.1
- Remove JitPack repository (no longer needed)
- Comment out mavenLocal() repository

## Test plan
- [ ] Verify project builds successfully with updated dependency
- [ ] Confirm no references to JitPack artifacts remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)