### PR TITLE
Refactor build config, bump versions, and fix content repo URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,17 @@
-VERSION=$(shell grep '^version =' build.gradle.kts | sed 's/.*"\(.*\)"/\1/')
+VERSION=$(shell grep '^version=' gradle.properties | cut -d= -f2)
+
+.PHONY: default clean clean-all build tests uberjar run-uber cc run versioncheck docker-push release deploy do-log upgrade-wrapper
 
 default: versioncheck
 
 clean:
 	./gradlew clean
 
+clean-all: clean
+	rm -rf build .gradle
+
 build: clean
-	./gradlew build -PreleaseDate=04/25/2026 -xtest
-
-local-build: clean
-	./gradlew build -PuseMavenLocal=true -PreleaseDate=04/25/2026 -xtest
-
-pull:
-	git pull
+	./gradlew build -xtest
 
 tests:
 	./gradlew --rerun-tasks check
@@ -32,10 +31,6 @@ run:
 versioncheck:
 	./gradlew dependencyUpdates
 
-#distro: clean build uberjar
-
-#docker: build-docker push-docker
-
 #build-docker:
 #	docker build -t pambrose/readingbat:${VERSION} .
 #
@@ -50,7 +45,7 @@ IMAGE_NAME := pambrose/readingbat
 
 docker-push:
 	# prepare multiarch
-	docker buildx use buildx 2>/dev/null || docker buildx create --use --name=buildx
+	docker buildx use readingbat-builder 2>/dev/null || docker buildx create --use --name=readingbat-builder
 	docker buildx build --platform ${PLATFORMS} --push -t ${IMAGE_NAME}:latest -t ${IMAGE_NAME}:${VERSION} .
 
 release: clean build uberjar docker-push

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -11,11 +12,9 @@ plugins {
 }
 
 description = "ReadingBat Site"
-group = "com.readingbat"
-version = "3.2.1"
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
-val releaseDate = (findProperty("releaseDate") as? String) ?: LocalDate.now().format(formatter)
+val releaseDate = (findProperty("releaseDate") as? String)?.takeIf { it.isNotBlank() } ?: LocalDate.now().format(formatter)
 
 buildConfig {
   buildConfigField("String", "SITE_NAME", "\"${project.name}\"")
@@ -60,11 +59,6 @@ tasks.shadowJar {
   exclude("LICENSE*")
 }
 
-// Heroku-only
-//tasks.register("stage") {
-//  dependsOn("build")
-//}
-
 tasks.named("build") {
   mustRunAfter("clean")
 }
@@ -74,7 +68,7 @@ tasks.test {
 
   testLogging {
     events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
-    exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-    showStandardStreams = true
+    exceptionFormat = TestExceptionFormat.FULL
+    showStandardStreams = false
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   readingbat0:
-    image: "pambrose/readingbat:3.2.1"
+    image: "pambrose/readingbat:3.2.2"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -8,7 +8,7 @@ services:
       - "8081:8081"
       - "8083:8083"
   readingbat1:
-    image: "pambrose/readingbat:3.2.1"
+    image: "pambrose/readingbat:3.2.2"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -16,7 +16,7 @@ services:
       - "8093:8083"
       - "8094:8084"
   readingbat2:
-    image: "pambrose/readingbat:3.2.1"
+    image: "pambrose/readingbat:3.2.2"
     restart: "always"
     env_file: docker_env_vars
     ports:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,8 @@
+group=com.readingbat
+version=3.2.2
+
 kotlin.code.style=official
 org.gradle.daemon=true
 org.gradle.caching=true
-org.gradle.configuration-cache=false
-org.gradle.jvmargs=-Xmx8g -Dkotlin.daemon.jvm.options=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.configuration-cache=true
+org.gradle.jvmargs=-Xmx6g -Dkotlin.daemon.jvm.options=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,8 +5,8 @@ versions = "0.54.0"
 buildconfig = "6.0.9"
 
 # Dependencies
-logging = "8.0.01"
-readingbat = "3.1.4"
+logging = "8.0.02"
+readingbat = "3.1.5"
 kotest = "6.1.11"
 ktor = "3.4.3"
 
@@ -21,7 +21,7 @@ kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.
 kotest-assertions-ktor = { module = "io.kotest:kotest-assertions-ktor", version.ref = "kotest" }
 
 ktor-bom = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
-ktor-server-test-host = { module = "io.ktor:ktor-server-test-host" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/machines/content/run.sh
+++ b/machines/content/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.2.1
+docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.2.2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,9 +2,6 @@ pluginManagement {
   repositories {
     gradlePluginPortal()
     mavenCentral()
-    if (providers.gradleProperty("useMavenLocal").orNull == "true") {
-      mavenLocal()
-    }
   }
 }
 
@@ -16,9 +13,6 @@ dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
     mavenCentral()
-    if (providers.gradleProperty("useMavenLocal").orNull == "true") {
-      mavenLocal()
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Move `group`, `version`, and `releaseDate` from `build.gradle.kts` to `gradle.properties`
- Tighten Makefile (`.PHONY`, `clean-all`, read VERSION from `gradle.properties`, rename buildx builder)
- Misc build config cleanup: pin `ktor-server-test-host`, import `TestExceptionFormat`, enable configuration cache, drop dead Heroku stage block
- Bump `readingbat-core` to 3.1.5, `kotlin-logging` to 8.0.02, Docker image refs to 3.2.2
- Fix `GitHubContent` repo names (stray dot in `-.content`)

## Test plan
- [x] \`./gradlew build -xtest\` passes
- [ ] \`./gradlew check\` (full test run) on CI
- [ ] Confirm \`make docker-push\` works with renamed buildx builder