### PR TITLE
Clean up Dockerfile and tighten build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-# Elastic Beanstalk Files
-.elasticbeanstalk/*
-.git
-.gitignore
+*
+!build/libs/server.jar
+!src/main/resources
+!src/main/kotlin/Content.kt
+!jmx

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,23 +7,18 @@ ENV APPLICATION_USER=readingbat
 ENV AGENT_CONFIG=/app/src/main/resources/application.conf
 
 # Then add the user, create the /app folder and give permissions to our user.
-RUN adduser --disabled-password --gecos '' $APPLICATION_USER && mkdir /app && chown -R $APPLICATION_USER /app
+RUN adduser -D -H $APPLICATION_USER && mkdir /app && chown -R $APPLICATION_USER /app
 
 # Mark this container to use the specified $APPLICATION_USER
 USER $APPLICATION_USER
 
-COPY build/libs/server.jar /app/server.jar
 COPY src/main/kotlin/Content.kt /app/src/main/kotlin/Content.kt
 COPY src/main/resources /app/src/main/resources
 COPY jmx /app/jmx
+COPY build/libs/server.jar /app/server.jar
 WORKDIR /app
 
-EXPOSE 8080
-EXPOSE 8081
-EXPOSE 8083
-EXPOSE 8091
-EXPOSE 8092
-EXPOSE 8093
+EXPOSE 8080 8081 8083 8091 8092 8093
 
 # Launch java to execute the jar with defaults intended for containers.
-ENTRYPOINT ["java", "-server", "-Xmx2048m", "-Dkotlin.script.classpath=/app/server.jar", "-Dlogback.configurationFile=/app/src/main/resources/logback.xml", "-javaagent:/app/jmx/jmx_prometheus_javaagent-1.5.0.jar=8081:/app/jmx/config.yaml", "-jar", "/app/server.jar"]
+ENTRYPOINT ["java", "-server", "-XX:MaxRAMPercentage=75", "-Dkotlin.script.classpath=/app/server.jar", "-Dlogback.configurationFile=/app/src/main/resources/logback.xml", "-javaagent:/app/jmx/jmx_prometheus_javaagent-1.5.0.jar=8081:/app/jmx/config.yaml", "-jar", "/app/server.jar"]


### PR DESCRIPTION
## Summary
- Fix Alpine \`adduser\` flags (BusyBox \`-D -H\` instead of GNU shadow-utils flags)
- Reorder COPYs so \`server.jar\` is last (improves layer caching for resource-only changes)
- Replace fixed \`-Xmx2048m\` with \`-XX:MaxRAMPercentage=75\` so heap scales with container memory limits
- Collapse six \`EXPOSE\` lines into one
- Switch \`.dockerignore\` to allowlist-style and drop stale Elastic Beanstalk entry

## Test plan
- [ ] \`docker build -t pambrose/readingbat:test .\` succeeds
- [ ] \`docker run --rm pambrose/readingbat:test\` starts up
- [ ] Confirm runtime user is \`readingbat\` (\`docker exec ... id\`)
- [ ] Confirm heap scales with \`docker run --memory=4g\` (jcmd / GC log)