### PR TITLE
Bump version to 3.2.3 and update readingbat-core to 3.1.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,71 +4,72 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 plugins {
-  application
-  alias(libs.plugins.kotlin.jvm)
-  alias(libs.plugins.ktor.plugin)
-  alias(libs.plugins.versions)
-  alias(libs.plugins.buildconfig)
+    application
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ktor.plugin)
+    alias(libs.plugins.versions)
+    alias(libs.plugins.buildconfig)
 }
 
 description = "ReadingBat Site"
 
-val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
-val releaseDate = (findProperty("releaseDate") as? String)?.takeIf { it.isNotBlank() } ?: LocalDate.now().format(formatter)
+val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+val releaseDate: String =
+    (findProperty("releaseDate") as? String)?.takeIf { it.isNotBlank() } ?: LocalDate.now().format(formatter)
 
 buildConfig {
-  buildConfigField("String", "SITE_NAME", "\"${project.name}\"")
-  buildConfigField("String", "SITE_VERSION", "\"${project.version}\"")
-  buildConfigField("String", "SITE_RELEASE_DATE", "\"$releaseDate\"")
+    buildConfigField("String", "SITE_NAME", "\"${project.name}\"")
+    buildConfigField("String", "SITE_VERSION", "\"${project.version}\"")
+    buildConfigField("String", "SITE_RELEASE_DATE", "\"$releaseDate\"")
 }
 
 dependencies {
-  implementation(libs.readingbat.core)
-  implementation(libs.kotlin.logging)
+    implementation(libs.readingbat.core)
+    implementation(libs.kotlin.logging)
 
-  implementation(platform(libs.ktor.bom))
-  testImplementation(libs.ktor.server.test.host)
+    implementation(platform(libs.ktor.bom))
+    testImplementation(libs.ktor.server.test.host)
 
-  testImplementation(libs.readingbat.kotest)
+    testImplementation(libs.readingbat.kotest)
 
-  testImplementation(libs.kotest.runner.junit5)
-  testImplementation(libs.kotest.assertions.core)
-  testImplementation(libs.kotest.assertions.ktor)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.assertions.ktor)
 }
 
 kotlin {
-  jvmToolchain(21)
+    jvmToolchain(21)
 }
 
 application {
-  mainClass = "ContentServerKt"
+    mainClass = "ContentServerKt"
 }
 
 ktor {
-  fatJar {
-    archiveFileName.set("server.jar")
-  }
+    fatJar {
+        archiveFileName.set("server.jar")
+    }
 }
 
 tasks.shadowJar {
-  isZip64 = true
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-  exclude("META-INF/*.SF")
-  exclude("META-INF/*.DSA")
-  exclude("META-INF/*.RSA")
-  exclude("LICENSE*")
+    isZip64 = true
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    exclude("META-INF/*.SF")
+    exclude("META-INF/*.DSA")
+    exclude("META-INF/*.RSA")
+    exclude("LICENSE*")
 }
 
 tasks.named("build") {
-  mustRunAfter("clean")
+    mustRunAfter("clean")
 }
 
 tasks.test {
-  useJUnitPlatform()
+    useJUnitPlatform()
 
-  testLogging {
-    events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
-    exceptionFormat = TestExceptionFormat.FULL
-    showStandardStreams = false
-  }
+    testLogging {
+        events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+        exceptionFormat = TestExceptionFormat.FULL
+        showStandardStreams = false
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   readingbat0:
-    image: "pambrose/readingbat:3.2.2"
+    image: "pambrose/readingbat:3.2.3"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -8,7 +8,7 @@ services:
       - "8081:8081"
       - "8083:8083"
   readingbat1:
-    image: "pambrose/readingbat:3.2.2"
+    image: "pambrose/readingbat:3.2.3"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -16,7 +16,7 @@ services:
       - "8093:8083"
       - "8094:8084"
   readingbat2:
-    image: "pambrose/readingbat:3.2.2"
+    image: "pambrose/readingbat:3.2.3"
     restart: "always"
     env_file: docker_env_vars
     ports:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.readingbat
-version=3.2.2
+version=3.2.3
 
 kotlin.code.style=official
 org.gradle.daemon=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ buildconfig = "6.0.9"
 
 # Dependencies
 logging = "8.0.02"
-readingbat = "3.1.5"
+readingbat = "3.1.6"
 kotest = "6.1.11"
 ktor = "3.4.3"
 

--- a/machines/content/run.sh
+++ b/machines/content/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.2.2
+docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.2.3


### PR DESCRIPTION
## Summary
- Bump project version from 3.2.2 to 3.2.3 (gradle.properties, docker-compose.yml, machines/content/run.sh)
- Update readingbat-core dependency from 3.1.5 to 3.1.6
- Reformat build.gradle.kts to 4-space indentation and add explicit type annotations

## Test plan
- [ ] `./gradlew build` succeeds
- [ ] Docker images build and run with new version tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)