### PR TITLE
Add Dockerfile HEALTHCHECK and chown copies to app user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,16 @@ RUN adduser -D -H $APPLICATION_USER && mkdir /app && chown -R $APPLICATION_USER 
 # Mark this container to use the specified $APPLICATION_USER
 USER $APPLICATION_USER
 
-COPY src/main/kotlin/Content.kt /app/src/main/kotlin/Content.kt
-COPY src/main/resources /app/src/main/resources
-COPY jmx /app/jmx
-COPY build/libs/server.jar /app/server.jar
+COPY --chown=$APPLICATION_USER:$APPLICATION_USER src/main/kotlin/Content.kt /app/src/main/kotlin/Content.kt
+COPY --chown=$APPLICATION_USER:$APPLICATION_USER src/main/resources /app/src/main/resources
+COPY --chown=$APPLICATION_USER:$APPLICATION_USER jmx /app/jmx
+COPY --chown=$APPLICATION_USER:$APPLICATION_USER build/libs/server.jar /app/server.jar
 WORKDIR /app
 
 EXPOSE 8080 8081 8083 8091 8092 8093
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -qO- http://localhost:8080/ping || exit 1
 
 # Launch java to execute the jar with defaults intended for containers.
 ENTRYPOINT ["java", "-server", "-XX:MaxRAMPercentage=75", "-Dkotlin.script.classpath=/app/server.jar", "-Dlogback.configurationFile=/app/src/main/resources/logback.xml", "-javaagent:/app/jmx/jmx_prometheus_javaagent-1.5.0.jar=8081:/app/jmx/config.yaml", "-jar", "/app/server.jar"]

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ versioncheck:
 	./gradlew dependencyUpdates
 
 #build-docker:
-#	docker build -t pambrose/readingbat:${VERSION} .
-#
+#	docker build -t pambrose/readingbat:${VERSION}
 #run-docker:
 #	docker run --rm --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:${VERSION}
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ buildconfig = "6.0.9"
 
 # Dependencies
 logging = "8.0.02"
-readingbat = "3.1.7"
+readingbat = "3.1.8"
 kotest = "6.1.11"
 ktor = "3.4.3"
 


### PR DESCRIPTION
## Summary
- Add `HEALTHCHECK` against `/ping` so Docker can report container health
- Use `COPY --chown=$APPLICATION_USER:$APPLICATION_USER` so copied files are owned by the non-root app user instead of root
- Minor Makefile comment cleanup
- Bump `readingbat-core` from 3.1.7 to 3.1.8

## Test plan
- [ ] `docker build` succeeds
- [ ] `docker run` shows container becoming `healthy` once `/ping` responds
- [ ] Files under `/app` are owned by `readingbat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)