### PR TITLE
Bump version to 3.2.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   readingbat0:
-    image: "pambrose/readingbat:3.2.4"
+    image: "pambrose/readingbat:3.2.5"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -8,7 +8,7 @@ services:
       - "8081:8081"
       - "8083:8083"
   readingbat1:
-    image: "pambrose/readingbat:3.2.4"
+    image: "pambrose/readingbat:3.2.5"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -16,7 +16,7 @@ services:
       - "8093:8083"
       - "8094:8084"
   readingbat2:
-    image: "pambrose/readingbat:3.2.4"
+    image: "pambrose/readingbat:3.2.5"
     restart: "always"
     env_file: docker_env_vars
     ports:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.readingbat
-version=3.2.4
+version=3.2.5
 
 kotlin.code.style=official
 org.gradle.daemon=true

--- a/machines/content/run.sh
+++ b/machines/content/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.2.4
+docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.2.5


### PR DESCRIPTION
## Summary
- Bump project version from 3.2.4 to 3.2.5 (gradle.properties, docker-compose.yml, machines/content/run.sh)

## Test plan
- [ ] `./gradlew build` succeeds
- [ ] Docker images build and run with new version tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)