### PR TITLE
Centralize Gradle and JVM versions in libs.versions.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VERSION=$(shell grep '^version=' gradle.properties | cut -d= -f2)
+GRADLE_VERSION=$(shell grep '^gradle = ' gradle/libs.versions.toml | cut -d'"' -f2)
 
 .PHONY: default clean clean-all build tests uberjar run-uber cc run versioncheck docker-push release deploy do-log upgrade-wrapper
 
@@ -58,4 +59,4 @@ do-log:
 	./secrets/app-log.sh
 
 upgrade-wrapper:
-	./gradlew wrapper --gradle-version=9.5.0 --distribution-type=bin
+	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,9 +18,10 @@ val releaseDate: String =
     (findProperty("releaseDate") as? String)?.takeIf { it.isNotBlank() } ?: LocalDate.now().format(formatter)
 
 buildConfig {
-    buildConfigField("String", "SITE_NAME", "\"${project.name}\"")
-    buildConfigField("String", "SITE_VERSION", "\"${project.version}\"")
-    buildConfigField("String", "SITE_RELEASE_DATE", "\"$releaseDate\"")
+    val stringType = "String"
+    buildConfigField(stringType, "SITE_NAME", "\"${project.name}\"")
+    buildConfigField(stringType, "SITE_VERSION", "\"${project.version}\"")
+    buildConfigField(stringType, "SITE_RELEASE_DATE", "\"$releaseDate\"")
 }
 
 dependencies {
@@ -38,7 +39,7 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(libs.versions.jvm.get().toInt())
 }
 
 application {
@@ -54,10 +55,7 @@ ktor {
 tasks.shadowJar {
     isZip64 = true
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    exclude("META-INF/*.SF")
-    exclude("META-INF/*.DSA")
-    exclude("META-INF/*.RSA")
-    exclude("LICENSE*")
+    listOf("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "LICENSE*").forEach { exclude(it) }
 }
 
 tasks.named("build") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.readingbat
-version=3.2.5
+version=3.2.6
 
 kotlin.code.style=official
 org.gradle.daemon=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,8 @@
 [versions]
+# Tooling
+gradle = "9.5.0"
+jvm = "21"
+
 # Plugins
 kotlin = "2.3.21"
 versions = "0.54.0"


### PR DESCRIPTION
## Summary
- Move the Gradle wrapper version (`9.5.0`) and JVM toolchain version (`21`) into `gradle/libs.versions.toml` under a new `# Tooling` block.
- `build.gradle.kts` now reads the JVM version via `libs.versions.jvm.get().toInt()`.
- `Makefile` derives `GRADLE_VERSION` from the catalog and uses it in the `upgrade-wrapper` target.
- Consolidate repeated string literals in `build.gradle.kts`: hoist the `"String"` type used by `buildConfigField` and collapse the four `shadowJar` `exclude(...)` calls into a single list `forEach`.

## Test plan
- [x] `./gradlew help` configures cleanly
- [x] `make -n upgrade-wrapper` resolves to `--gradle-version=9.5.0`
- [ ] CI build passes