### PR TITLE
Add project documentation and badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,190 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `.editorconfig` to standardize formatting across editors and CI
+- `detekt` and `kotlinter` plugins wired in via the version catalog
+- Self-documenting `make help` target and `make lint` / `make format` / `make detekt` shortcuts
+
+### Changed
+- Build release-date field now sourced from a `ValueSource` so it stays correct under the Gradle configuration cache
+- `BuildConfig` package aligned with the rest of the codebase as `com.readingbat.site`
+- `Makefile` modernized: guarded version extraction, `.PHONY` consolidated, portable `say` fallback
+- `ContentTests` moved into the `com.readingbat` package; copyright headers tidied
+- `gradle` and `jvm` versions centralized in `libs.versions.toml`
+
+## [3.2.5] — 2026-05-04
+
+### Added
+- Dockerfile `HEALTHCHECK` against `/ping`
+- `--chown` on `COPY` instructions so the runtime user owns its files
+
+### Changed
+- Bumped `readingbat-core` to 3.1.8
+
+## [3.2.4] — 2026-05-04
+
+### Changed
+- Bumped `readingbat-core` to 3.1.7
+
+## [3.2.3] — 2026-05-03
+
+### Changed
+- Bumped `readingbat-core` to 3.1.6
+- Reformatted `build.gradle.kts`
+- Tightened Docker build context and cleaned up the Dockerfile
+- Refactored build config and fixed content-repo URLs
+
+## [3.2.2] — 2026-04-25
+
+### Changed
+- Updated dependencies: `readingbat-core` 3.1.4, Ktor 3.4.3, Kotlin 2.3.21
+- Streamlined build configuration
+- Adjusted supported Docker platforms in the Makefile
+
+## [3.2.1] — 2026-04-12
+
+### Changed
+- Bumped `readingbat-core` to 3.1.3 (via 3.1.2)
+
+## [3.2.0] — 2026-04-04
+
+### Changed
+- Migrated to the `com.readingbat` package namespace
+- Bumped Gradle wrapper to 9.5.0, `versions` plugin to 0.54.0
+- Cleaned up repository declarations; added a conditional `mavenLocal` for development
+
+## [3.1.5] — 2026-03-28
+
+### Changed
+- Bumped `readingbat-core` to 3.0.10 (via 3.0.8)
+
+## [3.1.4] — 2026-03-26
+
+### Changed
+- Switched the Docker base image to `eclipse-temurin:21-jdk-alpine`
+- Updated assorted dependencies
+
+## [3.1.3] — 2026-03-21
+
+### Changed
+- Bumped `readingbat-core` to 3.0.5
+
+### Removed
+- Dead code and stale config flagged by code review
+
+## [3.1.2] — 2026-03-19
+
+### Changed
+- Upgraded the runtime to Java 21
+- Modernized the Dockerfile and bumped dependencies
+- Upgraded the JMX Prometheus Java agent from 0.14.0 to 1.5.0
+
+## [3.1.1] — 2026-03-18
+
+### Changed
+- Bumped dependencies and tweaked configuration settings
+
+## [3.1.0] — 2026-03-13
+
+### Added
+- `deploy` task in the `Makefile`
+
+### Changed
+- Upgraded `readingbat-core` to 3.0.1 and consolidated build configuration
+
+## [3.0.0] — 2026-03-12
+
+### Changed
+- Upgraded to Gradle 9.4.0 and `readingbat-core` 3.0.0
+
+## [2.1.0] — 2025-08-13
+
+### Changed
+- Upgraded to Gradle 9.0.0
+- Replaced the Shadow plugin with the Ktor plugin and adjusted build tasks
+- Reorganized `build.gradle.kts` and restored `cacheChangingModules` resolution strategy
+
+## [2.0.3] — 2025-04-14
+
+### Changed
+- Dependency refresh
+
+## [2.0.0] — 2024-12-04
+
+### Changed
+- Moved to Kotlin 2.1.0 and Ktor 3.0.1
+- Converted the build to use `libs.versions.toml`
+- Upgraded to Kotlin 2.2.0 over the 2.0.x line
+
+## [1.10.x] — 2022-10 → 2022-11
+
+Maintenance releases (1.10.5 → 1.10.8): dependency refreshes and build cleanups.
+
+## [1.8.0] — 2022-05-25
+
+### Changed
+- Cleanup after switching hosting to Digital Ocean Apps; dropped Papertrail from `logback.xml`
+
+## [1.7.0] — 2022-04-13
+
+### Changed
+- Upgraded to `readingbat-core` 1.26.0
+
+## [1.5.0] — 2021-12-14
+
+### Added
+- Release notes document
+
+## [1.4.0] — 2021-11-17
+
+Routine release.
+
+## [1.3.0] — 2021-08-27
+
+Routine release.
+
+## [1.2.x] — 2021-07-16
+
+### Changed
+- Upgraded `readingbat-core` through 1.20.0
+
+## [1.0.x → 1.1.x] — 2020-09 → 2021-06
+
+A long maintenance series covering early production hardening. Notable threads:
+
+- Postgres backend conversion; removal of Redis from websockets
+- Multi-server / multi-session support; teacher challenge reconnect logic
+- Real-time admin feedback; like/dislike on challenges; admin-prefs split
+- Kotlin script pools for answer comparison; cleanup of formatting code
+- IP geo-location info, Pingdom + Statuspage instrumentation
+- Initial Digital Ocean support; addition of JMX/Prometheus agent
+- MD5 digests for answer keys; Prometheus + Grafana dashboard links
+
+## [Initial] — 2020-04-23
+
+Project bootstrapped from `readingbat-core`'s site template.
+
+[Unreleased]: https://github.com/readingbat/readingbat-site/compare/3.2.5...HEAD
+[3.2.5]: https://github.com/readingbat/readingbat-site/compare/3.2.4...3.2.5
+[3.2.4]: https://github.com/readingbat/readingbat-site/compare/3.2.3...3.2.4
+[3.2.3]: https://github.com/readingbat/readingbat-site/compare/3.2.2...3.2.3
+[3.2.2]: https://github.com/readingbat/readingbat-site/compare/3.2.1...3.2.2
+[3.2.1]: https://github.com/readingbat/readingbat-site/compare/3.2.0...3.2.1
+[3.2.0]: https://github.com/readingbat/readingbat-site/compare/3.1.5...3.2.0
+[3.1.5]: https://github.com/readingbat/readingbat-site/compare/3.1.4...3.1.5
+[3.1.4]: https://github.com/readingbat/readingbat-site/compare/3.1.3...3.1.4
+[3.1.3]: https://github.com/readingbat/readingbat-site/compare/3.1.2...3.1.3
+[3.1.2]: https://github.com/readingbat/readingbat-site/compare/3.1.1...3.1.2
+[3.1.1]: https://github.com/readingbat/readingbat-site/compare/3.1.0...3.1.1
+[3.1.0]: https://github.com/readingbat/readingbat-site/compare/3.0.0...3.1.0
+[3.0.0]: https://github.com/readingbat/readingbat-site/compare/2.1.0...3.0.0
+[2.1.0]: https://github.com/readingbat/readingbat-site/compare/2.0.3...2.1.0
+[2.0.3]: https://github.com/readingbat/readingbat-site/compare/2.0.0...2.0.3
+[2.0.0]: https://github.com/readingbat/readingbat-site/releases/tag/2.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+Project-specific guidance for Claude when working in this repo. User-level preferences
+(commit policy, release/tag conventions, Kotest style) live in the user's global
+`~/.claude/CLAUDE.md` and take precedence — this file fills in repo specifics.
+
+## What this repo is
+
+`readingbat-site` is the deployable content host for [readingbat.com](https://readingbat.com).
+It is intentionally thin: the web server, routing, persistence, and challenge runtime all
+live in [`readingbat-core`](https://github.com/readingbat/readingbat-core), which this repo
+depends on as a binary artifact.
+
+The site's *content* is assembled in `src/main/kotlin/Content.kt`, which pulls together
+challenge definitions from external content repos:
+
+- [`readingbat-java-content`](https://github.com/readingbat/readingbat-java-content) — Java + Kotlin
+- [`readingbat-python-content`](https://github.com/readingbat/readingbat-python-content) — Python
+
+The application entry point is `src/main/kotlin/ContentServer.kt` (default package; main
+class `ContentServerKt`), which simply hands control to `ReadingBatServer.start(...)` from
+`readingbat-core`.
+
+## Layout
+
+```
+src/main/kotlin/Content.kt          # top-level content composition
+src/main/kotlin/ContentServer.kt    # main() entry point
+src/main/resources/application.conf # Ktor/HOCON config
+src/main/resources/logback.xml      # logging config
+src/test/kotlin/com/readingbat/     # Kotest tests (com.readingbat package)
+jmx/                                # JMX Prometheus agent + config
+machines/                           # production machine configs
+secrets/                            # deploy scripts (gitignored content)
+docs/release_notes.md               # deployment runbook (NOT per-version notes)
+RELEASE_NOTES.md                    # per-version highlights
+CHANGELOG.md                        # full version history
+```
+
+## Build, run, test
+
+All version numbers live in `gradle/libs.versions.toml` — including `jvm` and `gradle`
+itself. Treat that file as the single source of truth; do not pin versions in
+`build.gradle.kts`.
+
+```bash
+./gradlew build -x test     # build without tests
+./gradlew check             # run tests + verification
+./gradlew run               # run the app
+./gradlew buildFatJar       # produce build/libs/server.jar
+./gradlew lintKotlin detekt # lint
+./gradlew formatKotlin      # apply formatting
+./gradlew dependencyUpdates # check for newer deps
+./gradlew wrapper --gradle-version=$(grep '^gradle = ' gradle/libs.versions.toml | cut -d'"' -f2) --distribution-type=bin
+```
+
+`make help` lists Makefile shortcuts for the above (plus Docker/release flow).
+
+The build uses the Gradle configuration cache (`org.gradle.configuration-cache=true`).
+The release-date `BuildConfig` field is sourced from a `ValueSource` so it is
+re-evaluated each build instead of being frozen by the cache — keep that pattern
+when adding any build-time-dynamic config.
+
+## Tests
+
+Use [Kotest](https://kotest.io) `StringSpec` with an `init {}` block (matches the user's
+global preference). Tests live under `src/test/kotlin/com/readingbat/`. The shared
+test helpers come from `com.readingbat:readingbat-kotest`. Use MockK where mocking is
+needed.
+
+## Lint and formatting
+
+- `kotlinter` (ktlint) for formatting, with project-specific rule disables in `.editorconfig`
+- `detekt` for static analysis
+- `.editorconfig` sets 2-space indent for Kotlin and tab indent for `Makefile`
+- Keep both indent style and the disabled ktlint rules in sync if you add new file types
+
+## Versioning and releases
+
+- Version lives in `gradle.properties` (`version=...`)
+- Bump version → update `CHANGELOG.md` `[Unreleased]` → add a `RELEASE_NOTES.md` entry
+- GitHub release: tag without `v` prefix (e.g. `3.2.6`), title with `v` prefix (e.g. `v3.2.6`) — see global instructions
+- `docker-compose.yml` pins specific image tags; update those alongside any version bump that ships a new image
+
+## Docker / deploy
+
+- `Dockerfile` uses `eclipse-temurin:21-jdk-alpine`, runs as non-root `readingbat` user, exposes 8080/8081/8083/8091-8093, and has a `HEALTHCHECK` on `/ping`
+- `make release` builds and pushes multi-arch images (`linux/amd64,linux/arm64`) to `pambrose/readingbat:{latest,$VERSION}`
+- Deploy target is Digital Ocean Apps; runbook is in `docs/release_notes.md`
+- `make deploy` runs `./secrets/deploy-app.sh`
+
+## Things to remember
+
+- `readingbat-core` is the framework — site changes that look like framework work probably belong upstream
+- The `gradle` entry in `libs.versions.toml` is currently informational only; `gradle/wrapper/gradle-wrapper.properties` is what the wrapper actually uses. Keep them in sync when bumping (`make upgrade-wrapper` does this)
+- The `LICENSE*` exclude in `shadowJar` is broad — be aware if you ship a dep that requires attribution at the jar root
+- `BuildConfig` is generated under `com.readingbat.site`; the `main` function is in the default package (legacy; intentional)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,113 @@
 # ReadingBat Site
 
-[![Kotlin](https://img.shields.io/badge/%20language-Kotlin-red.svg)](https://kotlinlang.org/)
+[![Kotlin](https://img.shields.io/badge/language-Kotlin-7F52FF.svg?logo=kotlin&logoColor=white)](https://kotlinlang.org/)
+[![JDK](https://img.shields.io/badge/JDK-21-007396.svg?logo=openjdk&logoColor=white)](https://adoptium.net/)
+[![Ktor](https://img.shields.io/badge/Ktor-3.4-087CFA.svg?logo=ktor&logoColor=white)](https://ktor.io/)
+[![Gradle](https://img.shields.io/badge/Gradle-9.5-02303A.svg?logo=gradle&logoColor=white)](https://gradle.org/)
+[![License](https://img.shields.io/github/license/readingbat/readingbat-site.svg)](LICENSE.txt)
+[![GitHub release](https://img.shields.io/github/v/release/readingbat/readingbat-site.svg?logo=github)](https://github.com/readingbat/readingbat-site/releases)
+[![Docker Pulls](https://img.shields.io/docker/pulls/pambrose/readingbat.svg?logo=docker&logoColor=white)](https://hub.docker.com/r/pambrose/readingbat)
+[![Docker Image Size](https://img.shields.io/docker/image-size/pambrose/readingbat/latest.svg?logo=docker&logoColor=white)](https://hub.docker.com/r/pambrose/readingbat)
+[![Last commit](https://img.shields.io/github/last-commit/readingbat/readingbat-site.svg?logo=github)](https://github.com/readingbat/readingbat-site/commits/master)
 
-This repo has the content for [readingbat.com](https://readingbat.com).
-
-The underlying framework for this is the [readingbat-core](https://github.com/readingbat/readingbat-core) repo.
+The deployable content host for [readingbat.com](https://readingbat.com). This
+repo is intentionally thin: the web server, routing, persistence, and challenge
+runtime all live in [`readingbat-core`](https://github.com/readingbat/readingbat-core),
+which is consumed here as a binary dependency. What lives in this repo is the
+*content composition* and the deployment plumbing around it.
 
 ## Site Content
-* [Top-level Content.kt](git/readingbat-site/src/main/kotlin/Content.kt)
-* [Java and Kotlin Content](https://github.com/readingbat/readingbat-java-content/blob/master/src/main/kotlin/Content.kt)
-* [Python Content](https://github.com/readingbat/readingbat-python-content/blob/master/src/Content.kt)
+
+- [Top-level `Content.kt`](src/main/kotlin/Content.kt) — composes the full site
+- [Java and Kotlin content](https://github.com/readingbat/readingbat-java-content/blob/master/src/main/kotlin/Content.kt)
+- [Python content](https://github.com/readingbat/readingbat-python-content/blob/master/src/Content.kt)
 
 ## Code Content Repos
-* [Java and Kotlin](https://github.com/readingbat/readingbat-java-content)
-* [Python](https://github.com/readingbat/readingbat-python-content)
+
+- [Java and Kotlin](https://github.com/readingbat/readingbat-java-content)
+- [Python](https://github.com/readingbat/readingbat-python-content)
+
+## Requirements
+
+- JDK 21 (the Gradle toolchain will resolve one via [foojay](https://foojay.io/) if you don't already have it)
+- Docker + `buildx` (only needed for releases)
+
+All other versions — Gradle, Kotlin, Ktor, plugins — are pinned in
+[`gradle/libs.versions.toml`](gradle/libs.versions.toml).
+
+## Build and run
+
+```bash
+./gradlew run                # run the app locally
+./gradlew build -x test      # build without tests
+./gradlew buildFatJar        # produce build/libs/server.jar
+java -jar build/libs/server.jar
+```
+
+The app listens on `8080` (HTTP) by default, with additional ports for JMX and
+metrics — see the [`Dockerfile`](Dockerfile) for the full list.
+
+## Test
+
+```bash
+./gradlew check              # full verification (tests + lint)
+./gradlew test               # tests only
+```
+
+Tests use [Kotest](https://kotest.io) `StringSpec`. Test sources live under
+`src/test/kotlin/com/readingbat/`.
+
+## Lint and format
+
+```bash
+./gradlew lintKotlin detekt  # static analysis + style check
+./gradlew formatKotlin       # apply ktlint fixes
+```
+
+Project formatting rules are in [`.editorconfig`](.editorconfig).
+
+## Makefile shortcuts
+
+Most common workflows have a `make` target. Run `make help` for the full list:
+
+```bash
+make build                   # clean and build (no tests)
+make tests                   # full test suite
+make lint                    # lintKotlin + detekt
+make format                  # apply formatting
+make uberjar                 # build the fat jar
+make run-uber                # run the fat jar
+make release                 # build + push multi-arch Docker image
+make deploy                  # deploy via secrets/deploy-app.sh
+make upgrade-wrapper         # bump the Gradle wrapper to the catalog-pinned version
+```
+
+## Docker
+
+The image is built from `eclipse-temurin:21-jdk-alpine`, runs as a non-root
+`readingbat` user, and declares a `HEALTHCHECK` on `/ping`. `make release`
+publishes a multi-arch (`linux/amd64,linux/arm64`) image to
+`pambrose/readingbat:{latest,$VERSION}`.
+
+A multi-instance local composition is provided in
+[`docker-compose.yml`](docker-compose.yml).
+
+## Releasing and deploying
+
+1. Bump `version=` in `gradle.properties`.
+2. Move `[Unreleased]` entries in [`CHANGELOG.md`](CHANGELOG.md) under the new
+   version and add a highlights entry to [`RELEASE_NOTES.md`](RELEASE_NOTES.md).
+3. `make release` to build and push the Docker image.
+4. Follow the runbook in [`docs/release_notes.md`](docs/release_notes.md) to
+   roll the deployment on Digital Ocean.
+5. Cut a GitHub release: tag `X.Y.Z` (no `v` prefix), title `vX.Y.Z`.
+
+## Project conventions
+
+See [`CLAUDE.md`](CLAUDE.md) for repo conventions (layout, version-catalog
+discipline, Kotest patterns, configuration-cache safety) — useful for both
+humans and AI coding agents.
+
+## License
+
+Apache License 2.0 — see [`LICENSE.txt`](LICENSE.txt).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,96 @@
+# Release Notes
+
+Per-version highlights for `readingbat-site`. For the complete change log, see
+[`CHANGELOG.md`](CHANGELOG.md). For the *deployment runbook* (how to push a
+release to Digital Ocean), see [`docs/release_notes.md`](docs/release_notes.md).
+
+---
+
+## v3.2.6 — Unreleased
+
+Tooling and build hygiene.
+
+- Adopt `detekt` + `kotlinter` with a shared `.editorconfig` so editors and CI
+  agree on formatting.
+- Make the build safe under Gradle's configuration cache by switching the
+  release-date field to a `ValueSource`.
+- Centralize `gradle` and `jvm` versions in `libs.versions.toml`; modernize the
+  `Makefile` with a self-documenting `help` target and portable fallbacks.
+
+## v3.2.5 — 2026-05-04
+
+Container hardening.
+
+- Dockerfile now declares a `HEALTHCHECK` against `/ping` so orchestrators can
+  detect a wedged container without an external probe.
+- `COPY` instructions chown into the non-root runtime user so file ownership
+  matches the user the JVM runs as.
+- Bumped `readingbat-core` to 3.1.8.
+
+## v3.2.4 — 2026-05-04
+
+Routine `readingbat-core` refresh to 3.1.7.
+
+## v3.2.3 — 2026-05-03
+
+Build and Docker cleanups.
+
+- Tightened the Docker build context to reduce image churn.
+- Refactored `build.gradle.kts` and fixed broken content-repo URLs.
+- Bumped `readingbat-core` to 3.1.6.
+
+## v3.2.2 — 2026-04-25
+
+Dependency refresh: `readingbat-core` 3.1.4, Ktor 3.4.3, Kotlin 2.3.21. Multi-arch
+Docker platforms adjusted in the `Makefile`.
+
+## v3.2.1 — 2026-04-12
+
+Bumped `readingbat-core` to 3.1.3.
+
+## v3.2.0 — 2026-04-04
+
+Package migration.
+
+- Code moved under the `com.readingbat` namespace.
+- Gradle wrapper updated to 9.5.0; `versions` plugin to 0.54.0.
+- Added a conditional `mavenLocal` repository for local development against
+  unreleased `readingbat-core` builds.
+
+## v3.1.5 — 2026-03-28
+
+Bumped `readingbat-core` to 3.0.10.
+
+## v3.1.4 — 2026-03-26
+
+Switched the Docker base image to `eclipse-temurin:21-jdk-alpine` for a smaller
+image footprint. Assorted dependency updates.
+
+## v3.1.3 — 2026-03-21
+
+`readingbat-core` 3.0.5 plus dead-code cleanup from review.
+
+## v3.1.2 — 2026-03-19
+
+Java 21 runtime.
+
+- Upgraded the JVM toolchain and base image to Java 21.
+- Modernized the Dockerfile.
+- Upgraded the JMX Prometheus Java agent from 0.14.0 to 1.5.0.
+
+## v3.1.1 — 2026-03-18
+
+Routine dependency and config refresh.
+
+## v3.1.0 — 2026-03-13
+
+- Added a `deploy` Makefile target.
+- Upgraded `readingbat-core` to 3.0.1.
+
+## v3.0.0 — 2026-03-12
+
+Major bump alongside `readingbat-core` 3.0.0; Gradle 9.4.0.
+
+---
+
+For older releases (2.x and 1.x), see [`CHANGELOG.md`](CHANGELOG.md).

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,42 @@
+# readingbat-site
+
+> Deployable content host for [readingbat.com](https://readingbat.com). A thin
+> Kotlin/Ktor application that composes challenge content from external repos
+> and serves it via the [`readingbat-core`](https://github.com/readingbat/readingbat-core)
+> framework. The web server, persistence, and challenge runtime all live upstream
+> in `readingbat-core` — this repo provides only content composition and
+> deployment plumbing.
+
+The main entry point is `src/main/kotlin/ContentServer.kt`, which delegates to
+`ReadingBatServer.start(...)`. The content graph is assembled in
+`src/main/kotlin/Content.kt`. Tests use [Kotest](https://kotest.io) `StringSpec`
+under `src/test/kotlin/com/readingbat/`.
+
+## Docs
+
+- [README](README.md): project overview, build/run/test/deploy quickstart
+- [CLAUDE.md](CLAUDE.md): project-specific guidance for AI coding agents
+- [CHANGELOG](CHANGELOG.md): complete version history
+- [Release notes](RELEASE_NOTES.md): per-version highlights
+- [Deployment runbook](docs/release_notes.md): how to push a release to Digital Ocean
+
+## Source
+
+- [Content composition (`Content.kt`)](src/main/kotlin/Content.kt)
+- [Server entry point (`ContentServer.kt`)](src/main/kotlin/ContentServer.kt)
+- [Application config](src/main/resources/application.conf)
+- [Logback config](src/main/resources/logback.xml)
+- [Build script](build.gradle.kts)
+- [Version catalog](gradle/libs.versions.toml)
+
+## Related repos
+
+- [readingbat-core](https://github.com/readingbat/readingbat-core): the framework this site runs on
+- [readingbat-java-content](https://github.com/readingbat/readingbat-java-content): Java + Kotlin challenge content
+- [readingbat-python-content](https://github.com/readingbat/readingbat-python-content): Python challenge content
+
+## Operations
+
+- [Dockerfile](Dockerfile): `eclipse-temurin:21-jdk-alpine`, non-root, `/ping` healthcheck
+- [docker-compose.yml](docker-compose.yml): local multi-instance composition
+- [Makefile](Makefile): `make help` for the full task list


### PR DESCRIPTION
## Summary
- Add **CLAUDE.md** with repo-specific conventions (layout, version-catalog discipline, Kotest patterns, configuration-cache notes, release/deploy flow)
- Add **CHANGELOG.md** in Keep-a-Changelog format covering `[Unreleased]` plus the full tagged history with compare links
- Add **RELEASE_NOTES.md** at the repo root for per-version highlights (cross-links to `docs/release_notes.md`, which remains the deploy runbook)
- Add **llms.txt** following the [llmstxt.org](https://llmstxt.org/) format as a machine-readable project index
- Expand **README.md** with Requirements, Build/Run, Test, Lint, Makefile, Docker, and Releasing sections, and add live shields.io badges (language, JDK, Ktor, Gradle, license, latest release, Docker pulls + image size, last commit)

No source or build changes.

## Test plan
- [ ] README renders correctly on GitHub (badges resolve, internal links work)
- [ ] CHANGELOG compare links resolve against existing tags
- [ ] llms.txt links resolve from the GitHub blob view

🤖 Generated with [Claude Code](https://claude.com/claude-code)