### PR TITLE
Configure detekt and kotlinter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,18 @@ kotlin {
   jvmToolchain(libs.versions.jvm.get().toInt())
 }
 
+detekt {
+  source.setFrom("src/main/kotlin", "src/test/kotlin")
+  buildUponDefaultConfig = true
+  parallel = true
+}
+
+kotlinter {
+  ignoreFormatFailures = false
+  ignoreLintFailures = false
+  reporters = arrayOf("checkstyle", "plain")
+}
+
 application {
   mainClass = "ContentServerKt"
 }


### PR DESCRIPTION
## Summary
- Configure `detekt` to scan `src/main/kotlin` and `src/test/kotlin`, run in parallel, and build on top of the default config
- Configure `kotlinter` to fail the build on format/lint violations and emit both `checkstyle` and `plain` reporters

Follow-up to PR #18, which added the plugins but left them on their defaults.

## Test plan
- [x] `./gradlew lintKotlin detekt` succeeds locally
- [ ] CI lint job (when added) picks up the reporters

🤖 Generated with [Claude Code](https://claude.com/claude-code)