### PR TITLE
Release 3.3.0: Java 25 runtime, dependency bumps, and review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0] — 2026-06-15
+
 ### Added
 - `.editorconfig` to standardize formatting across editors and CI
 - `detekt` and `kotlinter` plugins wired in via the version catalog
 - Self-documenting `make help` target and `make lint` / `make format` / `make detekt` shortcuts
 
 ### Changed
+- Upgraded the JVM toolchain and Docker base image to Java 25 (`eclipse-temurin:25-jdk-alpine`)
+- Bumped `readingbat-core` to 3.2.0; adapted `ContentTests` to the now-`suspend` `correctAnswers()` API
+- Bumped Kotest to 6.2.0 and detekt to 2.0.0-alpha.4
 - Build release-date field now sourced from a `ValueSource` so it stays correct under the Gradle configuration cache
 - `BuildConfig` package aligned with the rest of the codebase as `com.readingbat.site`
 - `Makefile` modernized: guarded version extraction, `.PHONY` consolidated, portable `say` fallback
 - `ContentTests` moved into the `com.readingbat` package; copyright headers tidied
 - `gradle` and `jvm` versions centralized in `libs.versions.toml`
+- Dropped the redundant explicit `application` Gradle plugin (the Ktor plugin applies it transitively)
+- Narrowed the `shadowJar` exclude so third-party `LICENSE`/attribution files are retained in `server.jar`
+- Production logging now includes an ISO-8601 timestamp and thread name
+- Corrected a `docker-compose.yml` container-port mapping (`8084` → `8081`), bumped the pinned image tags (and `machines/content/run.sh`) to 3.3.0, and synced the `machines/` JMX agent references to 1.5.0
+
+### Removed
+- Legacy Heroku deploy descriptors `Procfile` and `system.properties` — the app deploys via Docker on Digital Ocean Apps, and the JVM version now lives solely in `gradle/libs.versions.toml` and the Dockerfile base image
 
 ## [3.2.5] — 2026-05-04
 
@@ -171,7 +183,8 @@ A long maintenance series covering early production hardening. Notable threads:
 
 Project bootstrapped from `readingbat-core`'s site template.
 
-[Unreleased]: https://github.com/readingbat/readingbat-site/compare/3.2.5...HEAD
+[Unreleased]: https://github.com/readingbat/readingbat-site/compare/3.3.0...HEAD
+[3.3.0]: https://github.com/readingbat/readingbat-site/compare/3.2.5...3.3.0
 [3.2.5]: https://github.com/readingbat/readingbat-site/compare/3.2.4...3.2.5
 [3.2.4]: https://github.com/readingbat/readingbat-site/compare/3.2.3...3.2.4
 [3.2.3]: https://github.com/readingbat/readingbat-site/compare/3.2.2...3.2.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,18 +80,18 @@ needed.
 - Version lives in `gradle.properties` (`version=...`)
 - Bump version → update `CHANGELOG.md` `[Unreleased]` → add a `RELEASE_NOTES.md` entry
 - GitHub release: tag without `v` prefix (e.g. `3.3.0`), title with `v` prefix (e.g. `v3.3.0`) — see global instructions
-- `docker-compose.yml` pins specific image tags; update those alongside any version bump that ships a new image
+- `docker-compose.yml` and `machines/content/run.sh` pin specific image tags; update those alongside any version bump that ships a new image
 
 ## Docker / deploy
 
-- `Dockerfile` uses `eclipse-temurin:21-jdk-alpine`, runs as non-root `readingbat` user, exposes 8080/8081/8083/8091-8093, and has a `HEALTHCHECK` on `/ping`
+- `Dockerfile` uses `eclipse-temurin:25-jdk-alpine`, runs as non-root `readingbat` user, exposes 8080/8081/8083/8091-8093, and has a `HEALTHCHECK` on `/ping`
 - `make release` builds and pushes multi-arch images (`linux/amd64,linux/arm64`) to `pambrose/readingbat:{latest,$VERSION}`
-- Deploy target is Digital Ocean Apps; runbook is in `docs/release_notes.md`
+- Deploy target is Digital Ocean Apps (Docker only — no Heroku); runbook is in `docs/release_notes.md`
 - `make deploy` runs `./secrets/deploy-app.sh`
 
 ## Things to remember
 
 - `readingbat-core` is the framework — site changes that look like framework work probably belong upstream
 - The `gradle-wrapper` entry in `libs.versions.toml` is currently informational only; `gradle/wrapper/gradle-wrapper.properties` is what the wrapper actually uses. Keep them in sync when bumping (`make upgrade-wrapper` does this)
-- The `LICENSE*` exclude in `shadowJar` is broad — be aware if you ship a dep that requires attribution at the jar root
+- `shadowJar` relies on `DuplicatesStrategy.EXCLUDE` to resolve duplicate license/metadata collisions; it no longer wildcard-excludes `LICENSE*`, so third-party attribution files are preserved in `server.jar`
 - `BuildConfig` is generated under `com.readingbat.site`; the `main` function is in the default package (legacy; intentional)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jdk-alpine
+FROM eclipse-temurin:25-jdk-alpine
 LABEL maintainer="Paul Ambrose <pambrose@mac.com>"
 
 # Define the user to use in this instance to prevent using root that even in a container, can be a security risk.

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ run: ## Run the app via Gradle
 versions: ## Report available dependency updates
 	./gradlew dependencyUpdates --no-configuration-cache --no-parallel
 
-docker-push: _require-version ## Build and push multi-arch Docker image
+docker-push: _require-version build ## Build and push multi-arch Docker image
 	# prepare multiarch
 	docker buildx use readingbat-builder 2>/dev/null || docker buildx create --use --name=readingbat-builder
 	docker buildx build --platform $(PLATFORMS) --push -t $(IMAGE_NAME):latest -t $(IMAGE_NAME):$(VERSION) .
@@ -67,7 +67,11 @@ deploy: ## Deploy the app via secrets/deploy-app.sh
 do-log: ## Tail the deployed app log
 	./secrets/app-log.sh
 
-upgrade-wrapper: _require-gradle-version ## Upgrade the Gradle wrapper to the pinned version
+upgrade-wrapper: _require-gradle-version ## Upgrade the Gradle wrapper to the catalog version
+	# Gradle's documented upgrade procedure: the first run rewrites
+	# gradle-wrapper.properties using the *old* wrapper jar; the second run
+	# regenerates the wrapper itself with the new version.
+	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin
 	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin
 
 _require-version:

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: java -Dagent.config=src/main/resources/application.conf -Dkotlin.script.classpath=build/libs/server.jar -jar build/libs/server.jar

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ReadingBat Site
 
 [![Kotlin](https://img.shields.io/badge/language-Kotlin-7F52FF.svg?logo=kotlin&logoColor=white)](https://kotlinlang.org/)
-[![JDK](https://img.shields.io/badge/JDK-21-007396.svg?logo=openjdk&logoColor=white)](https://adoptium.net/)
-[![Ktor](https://img.shields.io/badge/Ktor-3.4-087CFA.svg?logo=ktor&logoColor=white)](https://ktor.io/)
+[![JDK](https://img.shields.io/badge/JDK-25-007396.svg?logo=openjdk&logoColor=white)](https://adoptium.net/)
+[![Ktor](https://img.shields.io/badge/Ktor-3.5-087CFA.svg?logo=ktor&logoColor=white)](https://ktor.io/)
 [![Gradle](https://img.shields.io/badge/Gradle-9.5-02303A.svg?logo=gradle&logoColor=white)](https://gradle.org/)
 [![License](https://img.shields.io/github/license/readingbat/readingbat-site.svg)](LICENSE.txt)
 [![GitHub release](https://img.shields.io/github/v/release/readingbat/readingbat-site.svg?logo=github)](https://github.com/readingbat/readingbat-site/releases)
@@ -29,7 +29,7 @@ which is consumed here as a binary dependency. What lives in this repo is the
 
 ## Requirements
 
-- JDK 21 (the Gradle toolchain will resolve one via [foojay](https://foojay.io/) if you don't already have it)
+- JDK 25 (the Gradle toolchain will resolve one via [foojay](https://foojay.io/) if you don't already have it)
 - Docker + `buildx` (only needed for releases)
 
 All other versions — Gradle, Kotlin, Ktor, plugins — are pinned in
@@ -84,7 +84,7 @@ make upgrade-wrapper         # bump the Gradle wrapper to the catalog-pinned ver
 
 ## Docker
 
-The image is built from `eclipse-temurin:21-jdk-alpine`, runs as a non-root
+The image is built from `eclipse-temurin:25-jdk-alpine`, runs as a non-root
 `readingbat` user, and declares a `HEALTHCHECK` on `/ping`. `make release`
 publishes a multi-arch (`linux/amd64,linux/arm64`) image to
 `pambrose/readingbat:{latest,$VERSION}`.
@@ -95,12 +95,14 @@ A multi-instance local composition is provided in
 ## Releasing and deploying
 
 1. Bump `version=` in `gradle.properties`.
-2. Move `[Unreleased]` entries in [`CHANGELOG.md`](CHANGELOG.md) under the new
+2. Bump the pinned image tags in [`docker-compose.yml`](docker-compose.yml) and
+   `machines/content/run.sh` to the new version.
+3. Move `[Unreleased]` entries in [`CHANGELOG.md`](CHANGELOG.md) under the new
    version and add a highlights entry to [`RELEASE_NOTES.md`](RELEASE_NOTES.md).
-3. `make release` to build and push the Docker image.
-4. Follow the runbook in [`docs/release_notes.md`](docs/release_notes.md) to
+4. `make release` to build and push the Docker image.
+5. Follow the runbook in [`docs/release_notes.md`](docs/release_notes.md) to
    roll the deployment on Digital Ocean.
-5. Cut a GitHub release: tag `X.Y.Z` (no `v` prefix), title `vX.Y.Z`.
+6. Cut a GitHub release: tag `X.Y.Z` (no `v` prefix), title `vX.Y.Z`.
 
 ## Project conventions
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,16 +6,23 @@ release to Digital Ocean), see [`docs/release_notes.md`](docs/release_notes.md).
 
 ---
 
-## v3.3.0 — Unreleased
+## v3.3.0 — 2026-06-15
 
-Tooling and build hygiene.
+Java 25 runtime, dependency refresh, and build hygiene.
 
+- Upgraded the JVM toolchain and Docker base image to Java 25
+  (`eclipse-temurin:25-jdk-alpine`).
+- Bumped `readingbat-core` to 3.2.0, Kotest to 6.2.0, and detekt to
+  2.0.0-alpha.4.
 - Adopt `detekt` + `kotlinter` with a shared `.editorconfig` so editors and CI
   agree on formatting.
 - Make the build safe under Gradle's configuration cache by switching the
   release-date field to a `ValueSource`.
 - Centralize `gradle` and `jvm` versions in `libs.versions.toml`; modernize the
   `Makefile` with a self-documenting `help` target and portable fallbacks.
+- Remove the legacy Heroku deploy descriptors (`Procfile`, `system.properties`);
+  the app deploys via Docker on Digital Ocean Apps.
+- Production logs now carry an ISO-8601 timestamp and thread name.
 
 ## v3.2.5 — 2026-05-04
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,8 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 plugins {
-  application
+  // `application` is applied transitively by the Ktor plugin (io.ktor.plugin), which also wires
+  // up `mainClass`, `run`, and `buildFatJar`; no need to declare it explicitly.
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.ktor.plugin)
   alias(libs.plugins.versions)
@@ -74,7 +75,7 @@ ktor {
 tasks.shadowJar {
   isZip64 = true
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-  listOf("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "LICENSE*").forEach { exclude(it) }
+  listOf("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA").forEach { exclude(it) }
 }
 
 tasks.test {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   readingbat0:
-    image: "pambrose/readingbat:3.2.5"
+    image: "pambrose/readingbat:3.3.0"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -8,18 +8,18 @@ services:
       - "8081:8081"
       - "8083:8083"
   readingbat1:
-    image: "pambrose/readingbat:3.2.5"
+    image: "pambrose/readingbat:3.3.0"
     restart: "always"
     env_file: docker_env_vars
     ports:
       - "8090:8080"
       - "8093:8083"
-      - "8094:8084"
+      - "8094:8081"
   readingbat2:
-    image: "pambrose/readingbat:3.2.5"
+    image: "pambrose/readingbat:3.3.0"
     restart: "always"
     env_file: docker_env_vars
     ports:
       - "8070:8080"
       - "8073:8083"
-      - "8074:8084"
+      - "8074:8081"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
-gradle-wrapper = "9.5.1"
-jvm = "21"
-kotlin = "2.4.0"
-versions = "0.54.0"
 buildconfig = "6.0.10"
-detekt = "2.0.0-alpha.3"
+detekt = "2.0.0-alpha.4"
+gradle-wrapper = "9.5.1"
+jvm = "25"
+kotest = "6.2.0"
+kotlin = "2.4.0"
 kotlinter = "5.5.0"
-logging = "8.0.4"
-readingbat = "3.1.8"
-kotest = "6.1.11"
 ktor = "3.5.0"
+logging = "8.0.4"
+readingbat = "3.2.0"
+versions = "0.54.0"
 
 [libraries]
 readingbat-core = { module = "com.readingbat:readingbat-core", version.ref = "readingbat" }

--- a/llms.txt
+++ b/llms.txt
@@ -37,6 +37,6 @@ under `src/test/kotlin/com/readingbat/`.
 
 ## Operations
 
-- [Dockerfile](Dockerfile): `eclipse-temurin:21-jdk-alpine`, non-root, `/ping` healthcheck
+- [Dockerfile](Dockerfile): `eclipse-temurin:25-jdk-alpine`, non-root, `/ping` healthcheck
 - [docker-compose.yml](docker-compose.yml): local multi-instance composition
 - [Makefile](Makefile): `make help` for the full task list

--- a/machines/content/run.sh
+++ b/machines/content/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.2.5
+docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.3.0

--- a/machines/prometheus/jmx/notes.txt
+++ b/machines/prometheus/jmx/notes.txt
@@ -1,1 +1,1 @@
-Include jmx_prometheus_javaagent-0.13.0.jar in this dir
+Include jmx_prometheus_javaagent-1.5.0.jar in this dir

--- a/machines/prometheus/notes.txt
+++ b/machines/prometheus/notes.txt
@@ -12,4 +12,4 @@ jmx                               notes.txt             run.sh
 node_exporter-0.17.0.linux-amd64  prometheus-proxy.jar  simple.conf
 
 jmx/
-config.yaml  jmx_prometheus_javaagent-0.13.0.jar
+config.yaml  jmx_prometheus_javaagent-1.5.0.jar

--- a/machines/prometheus/run.sh
+++ b/machines/prometheus/run.sh
@@ -1,1 +1,1 @@
-nohup java -javaagent:jmx/jmx_prometheus_javaagent-0.13.0.jar=8081:jmx/config.yaml -jar prometheus-proxy.jar --config ./simple.conf &> log.out &
+nohup java -javaagent:jmx/jmx_prometheus_javaagent-1.5.0.jar=8081:jmx/config.yaml -jar prometheus-proxy.jar --config ./simple.conf &> log.out &

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
         <encoder>
             <!--            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} %-5level [%file:%line] - %msg%n%xEx</pattern>-->
             <!--            <pattern>%d{MM-dd HH:mm:ss.SSS} %-5level [%file:%line] - %msg%n%xEx</pattern>-->
-            <pattern>%-5level [%file:%line] - %msg%n%xEx</pattern>
+            <pattern>%d{ISO8601} [%thread] %-5level [%file:%line] - %msg%n%xEx</pattern>
         </encoder>
     </appender>
 

--- a/src/test/kotlin/com/readingbat/ContentTests.kt
+++ b/src/test/kotlin/com/readingbat/ContentTests.kt
@@ -31,6 +31,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeBlank
 import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
 
 class ContentTests : StringSpec() {
   init {
@@ -73,7 +74,7 @@ class ContentTests : StringSpec() {
           forEachGroup {
             forEachChallenge {
               forEachAnswer {
-                it shouldHaveAnswer correctAnswers[it.index]
+                runBlocking { it shouldHaveAnswer correctAnswers()[it.index] }
               }
             }
           }

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,0 @@
-java.runtime.version=21


### PR DESCRIPTION
## Summary

Releases **3.3.0** — a Java 25 runtime upgrade, a dependency refresh, and a batch of review-driven fixes.

### Runtime & dependencies
- JVM toolchain + Docker base image → **Java 25** (`eclipse-temurin:25-jdk-alpine`)
- `readingbat-core` 3.1.8 → **3.2.0** (`ContentTests` adapted to the now-`suspend` `correctAnswers()` API)
- Kotest 6.1.11 → **6.2.0**; detekt alpha.3 → **alpha.4**

### Build & packaging
- Dropped the redundant explicit `application` plugin (the Ktor plugin applies it transitively)
- Narrowed the `shadowJar` exclude so third-party `LICENSE`/attribution files are kept in `server.jar`

### Config & ops
- Fixed a `docker-compose.yml` container-port mapping (`8084` → `8081`); bumped image pins to `3.3.0` (incl. `machines/content/run.sh`)
- Synced `machines/` JMX agent references to `1.5.0`
- Production `logback` pattern now includes an ISO-8601 timestamp + thread name
- `make docker-push` now depends on `build`; `upgrade-wrapper` documents Gradle's two-pass procedure

### Removed
- Legacy Heroku descriptors `Procfile` and `system.properties` (deploy is Docker on Digital Ocean Apps)

### Docs
- `CHANGELOG.md` / `RELEASE_NOTES.md` dated **3.3.0 — 2026-06-15**
- `README.md` / `CLAUDE.md` / `llms.txt` JDK 21→25 and Ktor 3.4→3.5 references corrected

## Verification
- `./gradlew build -x test`, `./gradlew test`, and `clean buildFatJar lintKotlin detekt` all pass on JDK 25
- `eclipse-temurin:25-jdk-alpine` confirmed published for `amd64` + `arm64`

## Notes
- Not addressed (pre-existing, low-severity supply-chain hardening): committed JMX javaagent jar lacks a checksum/catalog entry; Gradle wrapper has no `distributionSha256Sum` pin.
- `pambrose/readingbat:3.3.0` is not on Docker Hub until `make release` runs, so the bumped compose/run.sh pins won't pull until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
