### PR TITLE
Simplify shadowJar signature-file excludes to a vararg call

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,7 +104,7 @@ fun Project.configureShadowJar() {
   tasks.shadowJar {
     isZip64 = true
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    listOf("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA").forEach { exclude(it) }
+    exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
   }
 }
 


### PR DESCRIPTION
## Summary

Minor build-script cleanup: replace `listOf("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA").forEach { exclude(it) }` in the `shadowJar` config with the vararg `exclude(...)` overload.

Identical behavior — the JAR signature files are still excluded so `DuplicatesStrategy.EXCLUDE` doesn't trip over them — just less noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)