### PR TITLE
Add GitHub Actions CI workflow on JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build, test, and lint
+        run: ./gradlew build


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow (`.github/workflows/ci.yml`) that builds, tests, and lints the project on every push and pull request to `master`.

- Runs on `ubuntu-latest`
- Sets up Temurin **JDK 25** — matching the Docker base image (`eclipse-temurin:25-jdk-alpine`) and the `jvm=25` toolchain in `gradle/libs.versions.toml`
- Uses `gradle/actions/setup-gradle@v4` for Gradle caching
- Runs `./gradlew build`, which covers compilation, tests, and lint verification

## Test plan

- CI will run against this PR and validate the workflow end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)