### PR TITLE
Bump readingbat-core to 3.3.1, versions plugin to 0.57.0, and trim CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Bumped `readingbat-core` to 3.3.1
+- Bumped the Gradle versions plugin to 0.57.0, whose plugin ID moved from `com.github.ben-manes.versions` to `io.github.ben-manes.versions`
+- Trimmed `CLAUDE.md` of guidance derivable from the repo itself (directory layout, standard Gradle invocations, the CI workflow restatement, and lint/Docker file summaries), keeping the gotchas, design rationale, and non-standard conventions
+
 ## [3.3.2] — 2026-07-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,41 +21,13 @@ The application entry point is `src/main/kotlin/ContentServer.kt` (default packa
 class `ContentServerKt`), which simply hands control to `ReadingBatServer.start(...)` from
 `readingbat-core`.
 
-## Layout
-
-```
-.github/workflows/ci.yml            # GitHub Actions CI (build + test + lint)
-src/main/kotlin/Content.kt          # top-level content composition
-src/main/kotlin/ContentServer.kt    # main() entry point
-src/main/resources/application.conf # Ktor/HOCON config
-src/main/resources/logback.xml      # logging config
-src/test/kotlin/com/readingbat/     # Kotest tests (com.readingbat package)
-jmx/                                # JMX Prometheus agent + config
-machines/                           # production machine configs
-secrets/                            # deploy scripts (gitignored content)
-docs/release_notes.md               # deployment runbook (NOT per-version notes)
-RELEASE_NOTES.md                    # per-version highlights
-CHANGELOG.md                        # full version history
-```
-
 ## Build, run, test
 
 All version numbers live in `gradle/libs.versions.toml` — including `jvm` and `gradle`
 itself. Treat that file as the single source of truth; do not pin versions in
 `build.gradle.kts`.
 
-```bash
-./gradlew build -x test     # build without tests
-./gradlew check             # run tests + verification
-./gradlew run               # run the app
-./gradlew buildFatJar       # produce build/libs/server.jar
-./gradlew lintKotlin detekt # lint
-./gradlew formatKotlin      # apply formatting
-./gradlew dependencyUpdates # check for newer deps
-./gradlew wrapper --gradle-version=$(grep '^gradle-wrapper = ' gradle/libs.versions.toml | cut -d'"' -f2) --distribution-type=bin
-```
-
-`make help` lists Makefile shortcuts for the above (plus Docker/release flow).
+`make help` lists the Makefile shortcuts for the build, lint, Docker, and release flow.
 
 The build uses the Gradle configuration cache (`org.gradle.configuration-cache=true`).
 The release-date `BuildConfig` field is sourced from a `ValueSource` so it is
@@ -64,42 +36,31 @@ when adding any build-time-dynamic config.
 
 ## CI
 
-`.github/workflows/ci.yml` runs on pushes and pull requests targeting `master`. It sets up
-JDK 25 (Temurin) via `actions/setup-java`, wires Gradle caching via
-`gradle/actions/setup-gradle`, then runs a single `./gradlew build`. Because `detekt` and
-`lintKotlin` both attach to `check`, that one command covers compile, tests, and lint — keep
-new verification tasks wired into `check` so CI picks them up without a workflow edit.
+Keep new verification tasks wired into `check` — CI runs a single `./gradlew build`, so
+anything attached to `check` is picked up without a workflow edit.
 
 ## Tests
 
-Use [Kotest](https://kotest.io) `StringSpec` with an `init {}` block (matches the user's
-global preference). Tests live under `src/test/kotlin/com/readingbat/`. The shared
-test helpers come from `com.readingbat:readingbat-kotest`. Use MockK where mocking is
-needed.
+The shared test helpers come from `com.readingbat:readingbat-kotest`.
 
 ## Lint and formatting
 
-- `kotlinter` (ktlint) for formatting, with project-specific rule disables in `.editorconfig`
-- `detekt` for static analysis
-- `.editorconfig` sets 2-space indent for Kotlin and tab indent for `Makefile`
-- Keep both indent style and the disabled ktlint rules in sync if you add new file types
+Keep both the indent style and the disabled ktlint rules in `.editorconfig` in sync if you
+add new file types.
 
 ## Versioning and releases
 
-- Version lives in `gradle.properties` (`version=...`)
 - Bump version → update `CHANGELOG.md` `[Unreleased]` → add a `RELEASE_NOTES.md` entry
-- GitHub release: tag without `v` prefix (e.g. `3.3.0`), title with `v` prefix (e.g. `v3.3.0`) — see global instructions
 - `docker-compose.yml` and `machines/content/run.sh` pin specific image tags; update those alongside any version bump that ships a new image
 
 ## Docker / deploy
 
-- `Dockerfile` uses `eclipse-temurin:25-jdk-alpine`, runs as non-root `readingbat` user, exposes 8080/8081/8083/8091-8093, and has a `HEALTHCHECK` on `/ping`
-- `make release` builds and pushes multi-arch images (`linux/amd64,linux/arm64`) to `pambrose/readingbat:{latest,$VERSION}`
-- Deploy target is Digital Ocean Apps (Docker only — no Heroku); runbook is in `docs/release_notes.md`
-- `make deploy` runs `./secrets/deploy-app.sh`
+Deploy target is Digital Ocean Apps (Docker only — no Heroku); the runbook is in
+`docs/release_notes.md`.
 
 ## Things to remember
 
+- `docs/release_notes.md` is the deployment runbook, **not** per-version notes (those live in `RELEASE_NOTES.md`)
 - `readingbat-core` is the framework — site changes that look like framework work probably belong upstream
 - The `gradle-wrapper` entry in `libs.versions.toml` is currently informational only; `gradle/wrapper/gradle-wrapper.properties` is what the wrapper actually uses. Keep them in sync when bumping (`make upgrade-wrapper` does this)
 - `shadowJar` relies on `DuplicatesStrategy.EXCLUDE` to resolve duplicate license/metadata collisions; it no longer wildcard-excludes `LICENSE*`, so third-party attribution files are preserved in `server.jar`. The jar-signature excludes are a single vararg `exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")` — add new patterns to that call rather than stacking separate `exclude` lines

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,8 @@ kotlin = "2.4.10"
 kotlinter = "5.6.0"
 ktor = "3.5.1"
 logging = "8.0.4"
-readingbat = "3.3.0"
-versions = "0.54.0"
+readingbat = "3.3.1"
+versions = "0.57.0"
 
 [libraries]
 readingbat-core = { module = "com.readingbat:readingbat-core", version.ref = "readingbat" }
@@ -25,7 +25,7 @@ ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref 
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-versions = { id = "com.github.ben-manes.versions", version.ref = "versions" }
+versions = { id = "io.github.ben-manes.versions", version.ref = "versions" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 ktor-plugin = { id = "io.ktor.plugin", version.ref = "ktor" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }


### PR DESCRIPTION
## Summary

- Bumps `readingbat-core` 3.3.0 → 3.3.1
- Bumps the Gradle versions plugin 0.54.0 → 0.57.0, which relocated its plugin ID from `com.github.ben-manes.versions` to `io.github.ben-manes.versions`
- Trims `CLAUDE.md` from 109 to 72 lines by removing content derivable from the repo itself

## CLAUDE.md trim

`CLAUDE.md` loads into context on every session, so anything a session could rediscover with a couple of tool calls is paid for twice. Removed:

| Section | Why it's derivable |
|---|---|
| `## Layout` block | `ls`/`find` already show it |
| Standard `./gradlew` command list | Stock Gradle invocations, all mirrored by existing `make` targets |
| `## CI` prose | Restates the 27-line `.github/workflows/ci.yml` |
| Kotest/`StringSpec`/MockK rule | Already in the always-loaded user-global `CLAUDE.md` |
| `kotlinter`/`detekt`/indent bullets | In `build.gradle.kts` and `.editorconfig`, and mechanically enforced by ktlint |
| `Dockerfile` summary, `make release`/`make deploy` | Restate `Dockerfile` and `Makefile` |
| Release tag/title convention | Duplicates the user-global instructions it already points at |

Kept: the design rationale (thin site, framework upstream), the configuration-cache/`ValueSource` note, the version-catalog directive, the Digital Ocean deploy target, and all of `## Things to remember`. The "`docs/release_notes.md` is the deployment runbook, **not** per-version notes" trap was the one non-derivable annotation inside the deleted layout block, so it is preserved as an explicit bullet.

## Test plan

- [x] `./gradlew clean build` — BUILD SUCCESSFUL (configuration resolves the relocated plugin ID)
- [x] `./gradlew test --rerun-tasks` — 2 tests, 0 failures, 0 errors (forced execution, not a cache hit)
- [x] `detekt` and `lintKotlin` pass via `check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)