### PR TITLE
Release 3.3.3: version bump, image-tag pins, and release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.3] — 2026-08-01
+
 ### Changed
 - Bumped `readingbat-core` to 3.3.1
 - Bumped the Gradle versions plugin to 0.57.0, whose plugin ID moved from `com.github.ben-manes.versions` to `io.github.ben-manes.versions`
@@ -208,7 +210,8 @@ A long maintenance series covering early production hardening. Notable threads:
 
 Project bootstrapped from `readingbat-core`'s site template.
 
-[Unreleased]: https://github.com/readingbat/readingbat-site/compare/3.3.2...HEAD
+[Unreleased]: https://github.com/readingbat/readingbat-site/compare/3.3.3...HEAD
+[3.3.3]: https://github.com/readingbat/readingbat-site/compare/3.3.2...3.3.3
 [3.3.2]: https://github.com/readingbat/readingbat-site/compare/3.3.1...3.3.2
 [3.3.1]: https://github.com/readingbat/readingbat-site/compare/3.3.0...3.3.1
 [3.3.0]: https://github.com/readingbat/readingbat-site/compare/3.2.5...3.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ add new file types.
 
 - Bump version → update `CHANGELOG.md` `[Unreleased]` → add a `RELEASE_NOTES.md` entry
 - `docker-compose.yml` and `machines/content/run.sh` pin specific image tags; update those alongside any version bump that ships a new image
+- `README.md`'s "Project conventions" section summarizes what *this* file covers — if you add or drop a section here, check that summary still matches
 
 ## Docker / deploy
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ A multi-instance local composition is provided in
 
 ## Project conventions
 
-See [`CLAUDE.md`](CLAUDE.md) for repo conventions (layout, version-catalog
-discipline, Kotest patterns, configuration-cache safety) — useful for both
-humans and AI coding agents.
+See [`CLAUDE.md`](CLAUDE.md) for repo conventions (version-catalog discipline,
+configuration-cache safety, `shadowJar` duplicate handling, and the gotchas that
+the code alone won't teach you) — useful for both humans and AI coding agents.
 
 ## License
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,18 @@ release to Digital Ocean), see [`docs/release_notes.md`](docs/release_notes.md).
 
 ---
 
+## v3.3.3 — 2026-08-01
+
+Dependency refresh and leaner agent guidance.
+
+- Bumped `readingbat-core` to 3.3.1.
+- Bumped the Gradle versions plugin to 0.57.0, which relocated its plugin ID
+  from `com.github.ben-manes.versions` to `io.github.ben-manes.versions`.
+- Trimmed `CLAUDE.md` of guidance derivable from the repo itself — the directory
+  layout, the standard `./gradlew` invocations, and the CI/Dockerfile/editorconfig
+  restatements — keeping the gotchas, design rationale, and non-standard
+  conventions.
+
 ## v3.3.2 — 2026-07-26
 
 CI automation and a dependency refresh.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   readingbat0:
-    image: "pambrose/readingbat:3.3.2"
+    image: "pambrose/readingbat:3.3.3"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -8,7 +8,7 @@ services:
       - "8081:8081"
       - "8083:8083"
   readingbat1:
-    image: "pambrose/readingbat:3.3.2"
+    image: "pambrose/readingbat:3.3.3"
     restart: "always"
     env_file: docker_env_vars
     ports:
@@ -16,7 +16,7 @@ services:
       - "8093:8083"
       - "8094:8081"
   readingbat2:
-    image: "pambrose/readingbat:3.3.2"
+    image: "pambrose/readingbat:3.3.3"
     restart: "always"
     env_file: docker_env_vars
     ports:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.readingbat
-version=3.3.2
+version=3.3.3
 
 kotlin.code.style=official
 org.gradle.daemon=true

--- a/machines/content/run.sh
+++ b/machines/content/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.3.2
+docker run --rm -d --env-file=docker_env_vars -p 8080:8080 pambrose/readingbat:3.3.3


### PR DESCRIPTION
## Summary

Release prep for **3.3.3**. The only functional change since `3.3.2` landed in #27 (`readingbat-core` 3.3.1, versions plugin 0.57.0, `CLAUDE.md` trim) — this PR is the version roll and the docs that go with it.

| File | Change |
|---|---|
| `gradle.properties` | `version=3.3.2` → `3.3.3` |
| `docker-compose.yml` | 3 image-tag pins → `pambrose/readingbat:3.3.3` |
| `machines/content/run.sh` | image-tag pin → `3.3.3` |
| `CHANGELOG.md` | `[Unreleased]` entries moved under `## [3.3.3] — 2026-08-01`; fresh empty `[Unreleased]`; compare links rewired |
| `RELEASE_NOTES.md` | New `v3.3.3` highlights section |
| `README.md` | "Project conventions" blurb corrected |
| `CLAUDE.md` | One bullet recording the README coupling |

## Why README changed

The `CLAUDE.md` trim in #27 removed the `## Layout` section and the Kotest patterns — but README's "Project conventions" section still advertised CLAUDE.md as covering exactly those two things. That blurb was silently falsified by the trim, so it is rewritten to match the file's current contents. The new `CLAUDE.md` bullet records the coupling so a future trim doesn't reintroduce the drift.

`llms.txt` was checked against the current tree — entry point, content composition, test location, docs list, and operations notes are all still accurate and it carries no version strings, so it needed no change.

## Test plan

- [x] `./gradlew clean build` — BUILD SUCCESSFUL, 16 of 18 tasks executed
- [x] Tests actually ran: 2 tests, 0 failures, 0 errors
- [x] Generated `BuildConfig.kt` reflects the bump: `SITE_VERSION = "3.3.3"`, `SITE_RELEASE_DATE = "08/01/2026"` — confirms the `ValueSource` release-date pattern still survives the configuration cache
- [x] No stale `3.3.2` strings remain in `gradle.properties`, `docker-compose.yml`, or `machines/content/run.sh`

## Not included

`make release` (multi-arch Docker push) and the Digital Ocean rollout are separate manual steps, as is cutting the GitHub release once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)